### PR TITLE
Enable linking phel from local to vendor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,14 @@ services:
       - '8443:8443'
     volumes:
       - 'wordpress_data:/bitnami/wordpress'
-      # linking phel-lang from local to vendor
+      # (optional) linking phel-lang from local to vendor
       - '../../phel-lang/phel-lang:/bitnami/phel-lang'
       # plugin mount cannot be inside named volume mount at least initially
       # https://github.com/moby/moby/issues/26051#issuecomment-125618978 (?)
       # workaround by symlinking plugin into plugins dir in post-init script
       - '.:/bitnami/phel-wp-plugin'
       - './docker-post-init-scripts:/docker-entrypoint-init.d'
+    working_dir: /bitnami/wordpress/wp-content/plugins/phel-wp-plugin
     depends_on:
       - mariadb
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - '8443:8443'
     volumes:
       - 'wordpress_data:/bitnami/wordpress'
+      # linking phel-lang from local to vendor
+      - '../../phel-lang/phel-lang:/bitnami/phel-lang'
       # plugin mount cannot be inside named volume mount at least initially
       # https://github.com/moby/moby/issues/26051#issuecomment-125618978 (?)
       # workaround by symlinking plugin into plugins dir in post-init script

--- a/docker-post-init-scripts/2_composer_install.sh
+++ b/docker-post-init-scripts/2_composer_install.sh
@@ -1,2 +1,9 @@
-cd /bitnami/wordpress/wp-content/plugins/phel-wp-plugin
+cd /bitnami/wordpress/wp-content/plugins/phel-wp-plugin || exit
 composer install --no-cache
+
+# if "local phel-lang" is not empty
+if [ -d "/bitnami/phel-lang" ] && [ "$(ls -A /bitnami/phel-lang 2>/dev/null)" ]; then
+  # override vendor phel-lang with symlink pointing to "local phel-lang"
+  rm -rf /bitnami/wordpress/wp-content/plugins/phel-wp-plugin/vendor/phel-lang/phel-lang
+  ln -s /bitnami/phel-lang /bitnami/wordpress/wp-content/plugins/phel-wp-plugin/vendor/phel-lang/phel-lang
+fi

--- a/docker-post-init-scripts/2_composer_install.sh
+++ b/docker-post-init-scripts/2_composer_install.sh
@@ -1,9 +1,20 @@
-cd /bitnami/wordpress/wp-content/plugins/phel-wp-plugin || exit
+#!/bin/bash
+
+PLUGIN_DIR="/bitnami/phel-wp-plugin"
+LOCAL_PHEL_LANG="/bitnami/phel-lang"
+VENDOR_PHEL_LANG="vendor/phel-lang"
+
+cd "$PLUGIN_DIR" || { echo "Failed to navigate to $PLUGIN_DIR. Exiting."; exit 1; }
+
 composer install --no-cache
 
-# if "local phel-lang" is not empty
-if [ -d "/bitnami/phel-lang" ] && [ "$(ls -A /bitnami/phel-lang 2>/dev/null)" ]; then
-  # override vendor phel-lang with symlink pointing to "local phel-lang"
-  rm -rf /bitnami/wordpress/wp-content/plugins/phel-wp-plugin/vendor/phel-lang/phel-lang
-  ln -s /bitnami/phel-lang /bitnami/wordpress/wp-content/plugins/phel-wp-plugin/vendor/phel-lang/phel-lang
+# Check if "local phel-lang" directory exists
+if [ -f "${LOCAL_PHEL_LANG}/bin/phel" ]; then
+  # Remove existing vendor phel-lang and create a symlink to local src
+  rm -rf "${VENDOR_PHEL_LANG}/phel-lang"
+  ln -s "$LOCAL_PHEL_LANG" "$VENDOR_PHEL_LANG"
+else
+  echo "No local phel found, keeping original from composer"
 fi
+
+echo "Phel version: " "$($PLUGIN_DIR/vendor/bin/phel -V)"

--- a/phel-config.php
+++ b/phel-config.php
@@ -1,9 +1,16 @@
 <?php
-$projectRootDir = __DIR__ . '/';
+
+use Phel\Config\PhelConfig;
 
 ini_set('xdebug.max_stack_frames', 300);
 ini_set('xdebug.max_nesting_level', 300);
 
-return (new \Phel\Config\PhelConfig())
-    ->setErrorLogFile($projectRootDir . 'error.log')
-    ->setSrcDirs(['src']);
+return (new PhelConfig())
+    ->setSrcDirs(['src'])
+    ->setTestDirs(['tests'])
+    ->setVendorDir('vendor')
+    ->setErrorLogFile('data/error.log')
+    ->setIgnoreWhenBuilding(['src/local.phel'])
+    ->setNoCacheWhenBuilding([])
+    ->setKeepGeneratedTempFiles(false)
+    ->setFormatDirs(['src', 'tests']);

--- a/src/main.phel
+++ b/src/main.phel
@@ -4,14 +4,14 @@
 (def posts (php/get_posts
             (to-php-array {"post_type" "post"
                            "numberposts" 2})))
+(defn current-user-name []
+  (-> (php/wp_get_current_user)
+      (php/-> user_login)))
 
 (defn phel-widget-content []
   (println "Hello, World!")
   (println "Your WordPress account name is: ")
-
-  (-> (php/wp_get_current_user)
-      (php/-> user_login)
-      println)
+  (println (current-user-name))
 
   (println (html [:div
                   [:h2 "All Posts"]


### PR DESCRIPTION
## 🥅  Goal

Enable overriding `phel-lang` code locally from vendor linked to the `phel-wp-plugin` on runtime.
This is very helpful to experiment and visualise how changes on phel-lang side would affect/help the wp-plugin project.

## 🔖  Changes

- Adding this volume to the wordpress service
  - `'../../phel-lang/phel-lang:/bitnami/phel-lang'` # (optional) linking phel from local to vendor

![Screenshot 2024-11-17 at 18 41 26](https://github.com/user-attachments/assets/e65393df-3ec7-4348-a495-0519fd3a1858)

I can see that from my local phel-lang src:

![Screenshot 2024-11-17 at 18 42 38](https://github.com/user-attachments/assets/7e418e91-0a4d-4589-b3ce-f218a75cfc28)


> If you don't have it, the regular phel-lang from composer will be installed & used.